### PR TITLE
Fix custom parameters

### DIFF
--- a/lib/transcoder.js
+++ b/lib/transcoder.js
@@ -376,7 +376,7 @@ function Transcoder(source) {
 	
 	/* Set custom FFmpeg parameter */
 	Transcoder.prototype.custom = function(key, value) {
-		this.args['key'] = [ '-' + key, value ];
+		this.args[key] = [ '-' + key, value ];
 		return this;
 	};
 	


### PR DESCRIPTION
In order to fix custom parameters chaining:

```
transcoder.custom("c:a", "copy")
  .custom("ac", 2)
  .custom("b:a", "64k")
  .custom("ar", 44100)
```
