### PR TITLE
refine the progress event regex.

### DIFF
--- a/lib/transcoder.js
+++ b/lib/transcoder.js
@@ -221,7 +221,7 @@ function Transcoder(source) {
 				}
 				
 				/* Track progress */
-				if (/^frame=/i.test(line)) {
+				if (/^(frame|size)=/i.test(line) ) {
 					if (!ended) _endParse();
 					var progress = _applyFilters(line, progressFilters);
 					if (metadata.input.duration) progress.progress = progress.time / metadata.input.duration;


### PR DESCRIPTION
As when transcoding audio files, it seems that there is no “frame=” but a “size=”. perhaps depending on ffmpeg version though (using 2.3.1).

example of ffmpeg output (transcoding mp3 to ogg):

```
ffmpeg version 2.3.1-   http://johnvansickle.com/ffmpeg/    Copyright (c) 2000-2014 the FFmpeg developers
  built on Jul 31 2014 10:24:31 with gcc 4.8 (Debian 4.8.3-6)
  configuration: --enable-gpl --enable-version3 --disable-shared --disable-debug --enable-runtime-cpudetect --enable-libmp3lame --enable-libx264 --enable-libwebp --enable-libspeex --enable-libvorbis --enable-libvpx --enable-libfreetype --enable-fontconfig --enable-libxvid --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libtheora --enable-libvo-aacenc --enable-libvo-amrwbenc --enable-gray --enable-libopenjpeg --enable-libopus --disable-ffserver --enable-libass --enable-gnutls --cc=gcc-4.8
  libavutil      52. 92.100 / 52. 92.100
  libavcodec     55. 69.100 / 55. 69.100
  libavformat    55. 48.100 / 55. 48.100
  libavdevice    55. 13.102 / 55. 13.102
  libavfilter     4. 11.100 /  4. 11.100
  libswscale      2.  6.100 /  2.  6.100
  libswresample   0. 19.100 /  0. 19.100
  libpostproc    52.  3.100 / 52.  3.100
Input #0, mp3, from 'pipe:':
  Duration: N/A, start: 0.000000, bitrate: 192 kb/s
    Stream #0:0: Audio: mp3, 44100 Hz, stereo, s16p, 192 kb/s
Output #0, ogg, to 'pipe:1':
  Metadata:
    encoder         : Lavf55.48.100
    Stream #0:0: Audio: vorbis (libvorbis), 44100 Hz, stereo, fltp
    Metadata:
      encoder         : Lavc55.69.100 libvorbis
Stream mapping:
[ { type: 'audio',
    codec: 'vorbis',
    samplerate: 44100,
    channels: 2,
    metadata: { encoder: 'Lavc55.69.100 libvorbis' } } ]
  Stream #0:0 -> #0:0 (mp3 (native) -> vorbis (libvorbis))
size=     142kB time=00:00:12.28 bitrate=  94.8kbits/s    
size=     211kB time=00:00:16.95 bitrate= 101.8kbits/s    
video:0kB audio:205kB subtitle:0kB other streams:0kB global headers:4kB muxing overhead: 2.896187%
```
