### PR TITLE
Handle additional format for size metadata

### DIFF
--- a/lib/transcoder.js
+++ b/lib/transcoder.js
@@ -83,13 +83,13 @@ function Transcoder(source) {
 				transform: parseInt
 			},
 			'size': {
-				match: /(\d+)x(\d+)(?:,|$)/i,
+				match: /(\d+)x(\d+)(?: \[.*?\])?(?:,|$)/i,
 				transform: function(r) {
 					if (r[1] && r[2]) return { width: parseInt(r[1]), height: parseInt(r[2]) };
 				}
 			},
 			'aspect': {
-				match: /(\d+)x(\d+)(?:,|$)/i,
+				match: /(\d+)x(\d+)(?: \[.*?\])?(?:,|$)/i,
 				transform: function(r) {
 					if (r[1] && r[2]) return parseInt(r[1]) / parseInt(r[2]);
 				}


### PR DESCRIPTION
There are other ways ffmpeg outputs the size than just \d+x\d+ followed
by a comma or newline.  There is a case where ffmpeg will output
additional metadata before the comma/newline in the form of
"600x338 [SAR 845:843 DAR 500:281]".  This does not work with the parser
as is, and will result in no size metadata being output which can be
problematic for anything relying on it being there.

For example, take a look at the metadata output for the given file: https://cdn1.lockerdome.com/uploads/381d165f31e9dcad7c08080f5f113d0472f97c540e43a3bccfad6ca950fc329c_:original
